### PR TITLE
Fix make lint command by updating flake8 max-complexity

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,4 +11,4 @@ exclude =
 per-file-ignores =
     # Allow longer lines in test files
     tests/*: E501
-max-complexity = 10
+max-complexity = 15


### PR DESCRIPTION
- Increase max-complexity from 10 to 15 in .flake8 config
- Matches the complexity used in CI workflow testing
- Ensures make lint command passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)