### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/parijatmukherjee/mohflow/security/code-scanning/5](https://github.com/parijatmukherjee/mohflow/security/code-scanning/5)

The best approach is to add a `permissions` block to the workflow file, `.github/workflows/ci.yml`. This should be added at the top workflow level (just after the `name` declaration and before `on:`), ensuring that all jobs default to least-privilege permissions unless overridden. The recommended starting point is `contents: read`, which grants just enough access to clone the repository and read its contents. If the `publish` job requires broader permissions (for example, writing release artifacts or tags), these can be explicit at the job level, but for the shown steps, `contents: read` suffices.

The fix involves inserting:
```yaml
permissions:
  contents: read
```
after the workflow `name: CI` line, maintaining indentation and YAML structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
