### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/parijatmukherjee/mohflow/security/code-scanning/4](https://github.com/parijatmukherjee/mohflow/security/code-scanning/4)

To fix the problem, you should explicitly declare a `permissions` block in the workflow to restrict the `GITHUB_TOKEN`'s access. The minimal safe starting point is `contents: read`, which grants the lowest level of access necessary for most workflows that do not require write access for repository contents (e.g., creating releases, modifying code, etc.). Since the shown workflow only builds and uploads to PyPI and does NOT interact with the repository contents or GitHub API using the `GITHUB_TOKEN`, setting `permissions: contents: read` at the top level of the workflow is appropriate. This addition should be made after the `name` field (line 1), before the `on` block (line 3), so that it applies to all jobs in the workflow unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
